### PR TITLE
Gulpfile Windows Compatibility Fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ var getIndexFiles = function(conf){
     });
 
     vendorFiles = vendorFiles.map(function(path){
-        return path.replace(/^.+bower_components\//i, '');
+        return path.replace(/\\/g, "\/").replace(/^.+bower_components\//i, '');
     });
 
     var files = {


### PR DESCRIPTION
Fix for running gulp task index on windows (previously forgot to change backslash to forward slash). Tested solution.